### PR TITLE
CIワークフローを追加（typecheck + test）

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,11 @@ updates:
       time: "09:00"
       timezone: Asia/Tokyo
     open-pull-requests-limit: 5
+    # 実行環境は node:22（Dockerfile.dev / package.json の engines >=22）。
+    # 型だけ先行して上げると Node 22 にない API が typecheck を通ってしまうので major は無視する
+    ignore:
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
     # マイナー・パッチはまとめて1本のPRにしてノイズを減らす
     groups:
       npm-minor-patch:
@@ -17,7 +22,7 @@ updates:
           - minor
           - patch
 
-  # ルートに .github/workflows/ を追加したら効く（現状は対象なし）
+  # .github/workflows/ci.yml の actions バージョンを監視する
   - package-ecosystem: github-actions
     directory: "/"
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+# PR と main への push で型チェックとテストを回す。
+# ローカルは Docker（compose.yml）だが、CI はランナーに直接 Node を入れる。
+# Dockerfile.dev の ca-certificates 対応は wrangler dev（外部TLS接続）用で CI には不要。
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      # package.json の engines（>=22）と Dockerfile.dev の node:22 に合わせる
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "22"
+          cache: npm
+
+      - run: npm ci
+
+      - name: 型チェック
+        run: npm run typecheck
+
+      - name: テスト
+        run: npm test


### PR DESCRIPTION
## 背景

リポジトリに CI が1本もなく、Dependabot PR が誰にも検証されないまま溜まっていた。

## 変更

- `.github/workflows/ci.yml` を追加。PR と main への push で `npm ci` → `npm run typecheck` → `npm test` を実行
  - Node は 22（`package.json` の `engines: >=22` / `Dockerfile.dev` の `node:22` に合わせる）
  - CI では Docker を使わない（Dockerfile.dev の ca-certificates 対応は wrangler dev 用で CI には不要）
- `.github/dependabot.yml`: 実行環境が node:22 なので `@types/node` の major 更新を ignore に追加（#76 をクローズした理由と同じ）

## 確認

ローカル（docker compose）で typecheck 通過・テスト 40件 全passを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)