### PR TITLE
記念品カタログの初期登録（本番）をNOTES.mdに記録

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -193,3 +193,41 @@ docker compose run --rm dev npx wrangler d1 execute mago-koro --local --command 
   email一意制約のため親アカウントと同一アドレスは不可、user_typeは単一値のため
   親兼任も不可 → 別アカウントとした）。ログイン・ダッシュボード表示確認済み
 - 記念品カタログは未登録のため、admin で `/admin/souvenirs/new` から登録が必要
+  → 2026-08-31 に登録済み（下記）
+
+## 記念品カタログの初期登録（2026-08-31 実施）
+
+Rails版 seeds（`archive/rails/db/seeds.rb`）と同じ3点を、本番 admin の
+`/admin/souvenirs/new` から手動登録した。コード変更・デプロイは不要な運用作業。
+
+| 商品名 | 価格 | 画像 |
+|---|---|---|
+| 子供の絵付きマグカップ | 2,500円 | souvenir-mug.jpg |
+| 子供の絵付きTシャツ | 3,500円 | souvenir-tshirt.jpg |
+| 子供の絵付きカレンダー | 2,000円 | souvenir-calendar.jpg |
+
+- 一覧は `created_at DESC, id DESC` 順なので、**カレンダー → Tシャツ → マグカップ**の
+  順に登録して、カタログの表示順をマグカップ→Tシャツ→カレンダーにした
+  （本番の souvenir id は 1=カレンダー / 2=Tシャツ / 3=マグカップ）
+
+### 商品画像の出典（すべて Pexels ライセンス。商用利用可・クレジット不要）
+
+| 画像 | 出典 | 撮影者 |
+|---|---|---|
+| マグカップ | <https://www.pexels.com/photo/beverage-caffeine-coffee-cup-606542/> | Jessica Lewis |
+| Tシャツ | <https://www.pexels.com/photo/white-t-shirt-hanging-on-a-rack-11671964/> | Marina Podrez |
+| カレンダー | <https://www.pexels.com/photo/rustic-december-calendar-page-with-vintage-style-35013837/> | Marina Endzhirgli |
+
+いずれも `.souvenir-image` の表示枠（`aspect-ratio: 4/3` / `object-fit: cover`）に
+合わせて 4:3 にトリミング済み（macOS の `sips`、長辺853〜960px・JPEG・30〜250KB）。
+ロゴ入りのマグカップや年号（2020/2021等）が写り込む候補は避けた。差し替えるときも
+Pexels / Unsplash のようにライセンスの明確な素材を使うこと。
+
+### 検証記録
+
+- ローカル（wrangler dev）: admin で3点登録 → 祖父母アカウントでカタログ表示 →
+  `/souvenirs/:id/image` が3件とも 200 image/jpeg。PC幅・390px幅ともレイアウト崩れなし
+- 本番: `/admin/souvenirs` で3件「掲載中・画像あり・注文0件」、
+  `/souvenirs/{1,2,3}/image` が表示されること（R2の実体まで）を確認
+- 本番では試し注文をしていない（`souvenir_orders` に実データを残さないため）。
+  注文フローの検証は 2026-07-20 のローカル一気通貫を参照


### PR DESCRIPTION
## 概要

2026-08-31 に本番の記念品カタログへ Rails版 seeds と同じ3点を登録した運用作業の記録を NOTES.md に追加します。コード変更はありません。

## 記録した内容

- 登録した3点（マグカップ 2,500円 / Tシャツ 3,500円 / カレンダー 2,000円）
- 商品画像の出典URL・撮影者・ライセンス（すべて Pexels。商用利用可・クレジット不要）と、4:3にトリミングした加工内容
- 一覧が `created_at DESC` 順のため、表示したい順の逆に登録する必要があること（本番の souvenir id は 1=カレンダー / 2=Tシャツ / 3=マグカップ）
- ローカル・本番それぞれの検証結果。本番では試し注文をしていないこと

## 検証

ドキュメントのみの変更のため、コードへの影響はありません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)