### PR TITLE
デプロイ手順をAPIトークン方式に更新

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -34,11 +34,16 @@ docker compose run --rm dev npm test                                           #
 docker compose run --rm dev npm run typecheck                                  # tsc
 ```
 
-デプロイ（ホストのwrangler認証をマウント）:
+デプロイ（`.env` の `CLOUDFLARE_API_TOKEN` を使う。gitignore済み）:
 
 ```bash
-docker compose run --rm -v "$HOME/Library/Preferences/.wrangler:/root/.config/.wrangler" dev npx wrangler deploy
+docker compose run --rm dev npx wrangler whoami   # 認証確認
+docker compose run --rm dev npx wrangler deploy
 ```
+
+トークンは Cloudflare ダッシュボードの API トークン（テンプレート「Edit Cloudflare
+Workers」）で発行して `.env` に置く。コンテナ内 `wrangler login`（OAuth）は
+コールバックが 127.0.0.1 バインドで届かないため使えない（NOTES.md参照）。
 
 ## プロジェクト構造
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -90,8 +90,8 @@ wrangler dev / test / deploy を全て実行する。
 - `node_modules` は名前付きボリューム（workerd バイナリがプラットフォーム別のため、
   ホストと共有してはいけない）
 - wrangler dev は `--ip 0.0.0.0` が必要（コンテナ外からのアクセス）
-- デプロイ時はホストの wrangler OAuth 認証をマウントして使う:
-  `docker compose run --rm -v "$HOME/Library/Preferences/.wrangler:/root/.config/.wrangler" dev npx wrangler deploy`
+- デプロイの認証は `.env` の `CLOUDFLARE_API_TOKEN`（2026-08-31 に切り替え。後述）:
+  `docker compose run --rm dev npx wrangler deploy`
 
 ## 検証記録（2026-07-18、ローカル wrangler dev）
 
@@ -231,3 +231,36 @@ Pexels / Unsplash のようにライセンスの明確な素材を使うこと�
   `/souvenirs/{1,2,3}/image` が表示されること（R2の実体まで）を確認
 - 本番では試し注文をしていない（`souvenir_orders` に実データを残さないため）。
   注文フローの検証は 2026-07-20 のローカル一気通貫を参照
+
+## デプロイ認証を API トークン方式に変更（2026-08-31）
+
+ホストの wrangler OAuth トークン（`~/Library/Preferences/.wrangler/config/default.toml`）は
+2026-07-20 で期限切れになり、マウント方式では
+「非対話環境では CLOUDFLARE_API_TOKEN が必要」と言われて deploy も remote D1 も通らなくなった。
+
+**コンテナ内 `wrangler login` は使えない。** OAuth のコールバックサーバーが
+コンテナ内の `127.0.0.1:8976` にバインドされるため、`-p 8976:8976` で転送しても
+（転送先はコンテナの外部インターフェース）届かず ERR_CONNECTION_RESET になる。
+ブラウザ側の Authorize 自体は成功しているのに受け取りだけが落ちる、という紛らわしい失敗をする。
+
+そこで API トークン方式に切り替えた:
+
+1. ダッシュボード（マイプロフィール → API トークン）でテンプレート
+   「Edit Cloudflare Workers」からトークンを発行。Account Resources は kotakky Account に限定
+   （最小構成なら Account の Workers Scripts:Edit / D1:Edit / Workers R2 Storage:Edit /
+   Account Settings:Read。**D1・R2 の権限は必須** — バインドしているため）
+2. `.env` に `CLOUDFLARE_API_TOKEN=...`（`compose.yml` の `env_file` が読む。
+   `.gitignore` の `/.env*` で除外済み）
+3. `docker compose run --rm dev npx wrangler whoami` で確認 →
+   `docker compose run --rm dev npx wrangler deploy`
+
+これで `-v "$HOME/Library/Preferences/.wrangler:..."` のマウントは不要になった。
+トークンが漏れたらダッシュボードから Roll / Delete で即失効できる。
+
+### 祖父母マイページに記念品導線を追加（2026-08-31 デプロイ）
+
+- カタログを公開しても祖父母の導線がヘッダーのリンクだけだったため、マイページに
+  「🎁 記念品をおくる」カード（記念品を見る / 注文の履歴）を追加（PR #83）。
+  注文履歴の戻りリンクも「← マイページに戻る」に統一
+- `.claude/rules/ui-guidelines.md` の祖父母メニューの記述をフェーズ2後の実態に更新
+- `wrangler deploy` 実行（Version 55805dd8-3558-47a7-b462-dca48b57d434）

--- a/README.md
+++ b/README.md
@@ -49,9 +49,17 @@ docker compose run --rm dev npm run typecheck
 ## デプロイ
 
 ```bash
-# ホストの wrangler 認証をコンテナに渡してデプロイ
-docker compose run --rm -v "$HOME/Library/Preferences/.wrangler:/root/.config/.wrangler" dev npx wrangler deploy
+# .env の CLOUDFLARE_API_TOKEN を使ってデプロイ（compose が env_file として読む）
+docker compose run --rm dev npx wrangler whoami   # 認証確認
+docker compose run --rm dev npx wrangler deploy
 ```
+
+トークンは Cloudflare ダッシュボード（マイプロフィール → API トークン）で
+テンプレート「Edit Cloudflare Workers」から発行し、`.env` に
+`CLOUDFLARE_API_TOKEN=...` として置く（`.gitignore` の `/.env*` で除外済み）。
+D1 と R2 をバインドしているので、Workers スクリプトだけの権限では deploy に失敗する。
+コンテナ内で `wrangler login`（OAuth）は使えない（コールバックが
+コンテナの 127.0.0.1 にバインドされるため、ホストのブラウザから届かない）。
 
 必要な事前準備（済んでいれば不要）:
 


### PR DESCRIPTION
## 背景

ホストの wrangler OAuth トークンが 2026-07-20 で期限切れになり、これまでの「ホストの認証をコンテナにマウントする」手順では非対話環境で deploy も remote D1 も通らなくなっていました。実際に本番デプロイをするにあたって `.env` の `CLOUDFLARE_API_TOKEN` 方式に切り替えたので、ドキュメントを実態に合わせます。

## 変更内容

- `.claude/CLAUDE.md` / `README.md`: デプロイコマンドを `docker compose run --rm dev npx wrangler deploy`（マウント不要）に更新。トークンの発行方法と、Workers スクリプトだけの権限では D1・R2 のバインドがあるため失敗することを追記
- `NOTES.md`:
  - 開発環境の節のデプロイ認証をAPIトークン方式に更新
  - 「デプロイ認証を API トークン方式に変更（2026-08-31）」の節を追加。**コンテナ内 `wrangler login` が使えない理由**（OAuthのコールバックがコンテナの 127.0.0.1 にバインドされるため、`-p 8976:8976` で転送しても届かず ERR_CONNECTION_RESET になる）を記録
  - 祖父母マイページの記念品導線（PR #83）の本番デプロイ記録（Version 55805dd8）を追記

ドキュメントのみの変更です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)